### PR TITLE
pyramid: fix non catched errors

### DIFF
--- a/saemref/files/pyramid.ini
+++ b/saemref/files/pyramid.ini
@@ -10,7 +10,3 @@ cubicweb.auth.authtkt.session.secret = {{ saemref.instance.authtk_session_secret
 cubicweb.auth.authtkt.session.secure = False
 cubicweb.auth.authtkt.persistent.secret = {{ saemref.instance.authtk_persistent_secret }}
 cubicweb.auth.authtkt.persistent.secure = False
-
-
-# https://www.cubicweb.org/13421901
-cubicweb.bwcompat.errorhandler = False


### PR DESCRIPTION
This was crashing uwsgi on 404 and 500 exceptions.