### PR TITLE
add instructions for upgrading saem-ref

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,22 @@ the database (WARNING: this will destroy existing database if exists).
 
 Then run: ``salt srv state.highstate`` to finish the installation.
 
+Upgrades
+========
+
+To force an upgrade to the latest version of saem-ref, connect to the minion as
+root, then run::
+
+    [root@minion] % supervisorctl stop all
+    [root@minion] % salt-call state.sls saemref.install pillar='{"upgrade": true}'
+    # be patient
+    [root@minion] % su - saemref
+    [saemref@minion] % . venv/bin/activate
+    (venv) [saemref@minion] % cubicweb-ctl upgrade saemref
+    # proceed to the cubicweb upgrade process
+    (venv) [saemref@minion] % exit
+    [root@minion] % supervisorctl start all
+
 Testing
 =======
 

--- a/saemref/install.sls
+++ b/saemref/install.sls
@@ -63,6 +63,12 @@ legacy cleanup:
       - uwsgi
       - uwsgi-plugin-python
 
+{% if pillar.get('upgrade', False) %}
+drop old virtualenv:
+  file.absent:
+    - name: /home/{{ saemref.instance.user }}/venv
+{% endif %}
+
 venv:
   virtualenv.managed:
     - name: /home/{{ saemref.instance.user }}/venv
@@ -70,6 +76,9 @@ venv:
     - user: {{ saemref.instance.user }}
     - require:
       - pkg: legacy cleanup
+      {% if pillar.get('upgrade', False) %}
+      - file: drop old virtualenv
+      {% endif %}
 
 cubicweb in venv:
   pip.installed:


### PR DESCRIPTION
In saemref.install state, read pillar "upgrade" that is passed to the
command line to force the recreation of the virtualenv.

Document the full upgrade procedure in README.