### PR TITLE
[conf] Set default interface to 0.0.0.0

### DIFF
--- a/saemref/files/all-in-one.conf.j2
+++ b/saemref/files/all-in-one.conf.j2
@@ -146,7 +146,7 @@ logstat-file=/tmp/{{ saemref.instance.name }}-all-in-one.stats
 {{ config('port', saemref.instance.port) }}
 
 # http server address on which to listen (default to everywhere)
-interface=
+interface=0.0.0.0
 
 # maximum length of HTTP request. Default to 100 MB.
 max-post-length=100MB


### PR DESCRIPTION
so "cubicweb-ctl pyramid" will work with recent pyramid packages.