### PR TITLE
Do not rely on epel-formula and install epel-release package directly

### DIFF
--- a/saemref/install.sls
+++ b/saemref/install.sls
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 {% from "saemref/map.jinja" import saemref with context %}
 
-include:
 {% if grains['os_family'] == 'RedHat' %}
-  - epel
+include:
   - postgres.upstream
+
+epel-release:
+  pkg.installed
 {% endif %}
 
 pip-setuptools:

--- a/test/minion.conf
+++ b/test/minion.conf
@@ -5,7 +5,6 @@ fileserver_backend:
     - git
 
 gitfs_remotes:
-    - git://github.com/saltstack-formulas/epel-formula.git
     - git://github.com/saltstack-formulas/postgres-formula.git
 
 file_roots:


### PR DESCRIPTION
It looks like "epel-release" package can be installed directly, at least on centos (not sure about redhat, but as we only theoretically support it, who knows...). Since epel-formula is currently broken because because the directory structure of http://download.fedoraproject.org changed, let's get rid of it!