### PR TITLE
Revert "Set cubicweb.auth.authtk.*.secure = true in pyramid.ini"

### DIFF
--- a/saemref/files/pyramid.ini
+++ b/saemref/files/pyramid.ini
@@ -1,8 +1,8 @@
-{% from "saemref/map.jinja" import saemref with context -%}
+{% from "saemref/map.jinja" import saemref, session_secure with context -%}
 [main]
 cubicweb.profile = no
 cubicweb.session.secret = {{ saemref.instance.sessions_secret }}
 cubicweb.auth.authtkt.session.secret = {{ saemref.instance.authtk_session_secret }}
-cubicweb.auth.authtkt.session.secure = true
+cubicweb.auth.authtkt.session.secure = {{ session_secure }}
 cubicweb.auth.authtkt.persistent.secret = {{ saemref.instance.authtk_persistent_secret }}
-cubicweb.auth.authtkt.persistent.secure = true
+cubicweb.auth.authtkt.persistent.secure = {{ session_secure }}

--- a/saemref/map.jinja
+++ b/saemref/map.jinja
@@ -17,3 +17,5 @@
 %}
 
 {% set is_docker_build = (salt['cmd.retcode']('/bin/sh -c "(readlink -f /sbin/init | grep -q systemd) && ! (readlink -f /proc/1/exe | grep systemd)"') == 0) %}
+
+{% set session_secure = 'true' if salt['pillar.get']('saemref:lookup:instance:base_url').startswith('https://') else 'false' %}


### PR DESCRIPTION
This reverts commit 62f757e8f0981b66e96e4d16431e37674c343fa1.

This commit break instance not using https and we still have such
instances.